### PR TITLE
Net::Dropbox putfile() Change

### DIFF
--- a/lib/Net/Dropbox/API.pm
+++ b/lib/Net/Dropbox/API.pm
@@ -309,8 +309,9 @@ sub _talk {
         token_secret => $self->access_secret,
     );
     if($filename) {
-        $opts{extra_params}{file} = $filename;
-        $opts{request_url} = 'http://api-content.dropbox.com/0/'.$command;
+        push @{$content->{file}},$filename;
+        $opts{request_url} = "http://api-content.dropbox.com/0/$command/?".
+            "file=$filename";
     }
 
     my $request = Net::OAuth->request("protected resource")->new( %opts );


### PR DESCRIPTION
Hi, Lenz.  Me again.  I was having trouble getting Net::Dropbox's putfile() to allow me to specify a different filename to the data I was sending to Dropbox -- the third parameter -- and I eventually chased it down to a missing "file" argument.  In my testing, it works in either case now -- a new filename or the same as the local one.

Thanks!
