### PR TITLE
Dropbox Changed the authorized url and Net::OAuth callback_confirmed support.

### DIFF
--- a/lib/Net/Dropbox/API.pm
+++ b/lib/Net/Dropbox/API.pm
@@ -93,7 +93,7 @@ sub login {
         $self->request_secret($response->token_secret);
         print "Got Request Token ", $response->token, "\n" if $self->debug;
         print "Got Request Token Secret ", $response->token_secret, "\n" if $self->debug;
-        return 'http://api.dropbox.com/0/oauth/authorize?oauth_token='.$response->token.'&oauth_callback='.$self->callback_url;
+        return 'https://www.dropbox.com/0/oauth/authorize?oauth_token='.$response->token.'&oauth_callback='.$self->callback_url;
     }
     else {
         $self->error($res->status_line);

--- a/lib/Net/Dropbox/API.pm
+++ b/lib/Net/Dropbox/API.pm
@@ -82,6 +82,7 @@ sub login {
         timestamp => time,
         nonce => $self->nonce,
         callback => $self->callback_url,
+        callback_confirmed => ($self->callback_url ? 'true' : undef)
     );
 
     $request->sign;


### PR DESCRIPTION
## Dropbox Changed the authorized url.
- https://api.dropbox.com/developers/web_docs#authentication-for-web
- http://dl.dropbox.com/u/11475683/dropbox-authorized-url.png
## Net::OAuth callback_confirmed support.
- http://search.cpan.org/~kgrennan/Net-OAuth-0.27/lib/Net/OAuth.pm#OAUTH_1.0A
- http://oauth.net/core/1.0a/#rfc.section.6.1.2
