### PR TITLE
fix list path prefix /

### DIFF
--- a/lib/Net/Dropbox/API.pm
+++ b/lib/Net/Dropbox/API.pm
@@ -197,6 +197,7 @@ sub list {
         $opts = shift;
     }
     my $path = shift || '';
+    $path = '/' . $path if length $path && substr($path, 0, 1) ne '/';
 
     my $uri = URI->new('files/'.$self->context.$path);
     $uri->query_form($opts) if scalar keys %$opts;

--- a/lib/Net/Dropbox/API.pm
+++ b/lib/Net/Dropbox/API.pm
@@ -196,8 +196,9 @@ sub list {
           # optional option hash present
         $opts = shift;
     }
-    my $path = shift || '';
-    $path = '/' . $path if length $path && substr($path, 0, 1) ne '/';
+    my $path = shift;
+    $path = '' unless defined $path;
+    $path = '/'.$path if $path=~m|^[^/]|;
 
     my $uri = URI->new('files/'.$self->context.$path);
     $uri->query_form($opts) if scalar keys %$opts;


### PR DESCRIPTION
version 1.5 is "sub list" Specification has changed.
Was as good as either.
## version 1.4

```
$api->list("Photos");
```
## version 1.5

```
$api->list("/Photos");
```
### diff

```
-    return from_json($self->_talk('files/'.$self->context.'/'.$path));
+    my $uri = URI->new('files/'.$self->context.$path);
```
## patch

```
$api->list("Photos");
or
$api->list("/Photos");
```
