### PR TITLE
Fix for previous Net--Dropbox pull request

### DIFF
--- a/lib/Net/Dropbox/API.pm
+++ b/lib/Net/Dropbox/API.pm
@@ -440,10 +440,8 @@ sub _talk {
             $data = from_json($res->content);
         };
         if($@) {
-            # got invalid json from server
-            return to_json({ error => "Invalid JSON server response",
-                             http_response_code => $res->code(),
-                           });
+            # this doesn't look like JSON, might be file content
+            return $res->content;
         }
         $data->{http_response_code} = $res->code();
         return to_json($data);


### PR DESCRIPTION
Backed out error response on malformed JSON, because getfile() returns just content an no JSON. This keeps the API backwards compatible.
